### PR TITLE
Update petooh.js

### DIFF
--- a/JavaScript/petooh.js
+++ b/JavaScript/petooh.js
@@ -19,7 +19,7 @@
     // constructor desu
     var Petooh = function (options) {
         this.options = options || {};
-        this.filter = new RegExp(/^[adehkKoOru]$/);
+        this.filter = new RegExp('^[adehkKoOru]$');
 
         this.cleanBrain();
     };


### PR DESCRIPTION
`RegExp` constructor prepares regex (returns the instance of `RegExp` class), `/.../` literal make the same. You shouldn't pass prepared regex to the `Regex` constructor, since it awaits for a string. It is useful when you need to interpolate variable inside your regex.